### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,7 +14,7 @@ ArduinoFacil	KEYWORD1
 
 estableceComoSalida	KEYWORD2
 estableceComoEntrada	KEYWORD2
-estableceComoEntradaSubida KEYWORD2
+estableceComoEntradaSubida	KEYWORD2
 enciende	KEYWORD2
 apaga	KEYWORD2
 entrada	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords